### PR TITLE
Replaces many http requests for creating and deleting many cards with single requests

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -976,14 +976,15 @@ export default {
         // If no currentCardId, then we are creating a new card
         if (this.currentCardId === "") {
           // Create a card in the data store usinf data from the form
-          await db.create(
+          await db.create([
             {
               question: this.newFront,
               answer: this.newBack,
               flipped: false,
               reads: this.cards[0] ? this.cards[0].reads : 0,
               difficulty: 0,
-            },
+            }
+            ],
             { remote: this.useRemoteStorage }
           );
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -595,25 +595,23 @@ export default {
       }
     },
     addDataFromFile: async function(cards, event) {
-      let promCreate = [];
+      let cardsToCreate = [];
       let reads = this.cards[0] ? this.cards[0].reads : 0;
       for (let card of cards) {
-        promCreate.push(
-          db.create(
+        cardsToCreate.push(
             {
               question: card.question,
               answer: card.answer,
               flipped: false,
               reads: reads,
               difficulty: 0,
-            },
-            { remote: this.useRemoteStorage }
-          )
+            }
         );
       }
 
+
       event.target.classList.toggle("wait");
-      await Promise.all(promCreate);
+      await db.create(cardsToCreate, { remote: this.useRemoteStorage });
       // Reload the cards from the data store to update the view and shuffle
       this.cards = await this.loadCards();
       event.target.classList.toggle("wait");
@@ -680,16 +678,9 @@ export default {
       document.body.removeChild(element);
     },
     deleteAllData: async function(event) {
-      // We will be deleting all cards at once. For this we will need to
-      //  to create an array of promises and wait for them all to resolve
-      let promDelete = [];
-      for (let card of this.cards) {
-        promDelete.push(db.delete(card.id, { remote: this.useRemoteStorage }));
-      }
-
       event.target.classList.toggle("wait");
 
-      await Promise.all(promDelete);
+      await db.delete(null, { remote: this.useRemoteStorage });
 
       // Reload the now empty set of cards from the data store to update the view
       this.cards = await this.loadCards();
@@ -888,55 +879,44 @@ export default {
       this.showConfirmDelete = false;
     },
     deleteRemoteCards: async function(cards) {
-      // We will be deleting many remote cards at once and then recreating them locally.
-      // For this we will need to create an array of promises and wait for them all
-      // to resolve
-      let promDelete = [];
-      let promCreate = [];
+      // We will be deleting all remote cards at once and then recreating them locally.
+      let cardsToCreate = [];
       for (let card of cards) {
-        promDelete.push(db.delete(card.id, { remote: true }));
-        promCreate.push(
-          db.create(
+        cardsToCreate.push(
             {
               question: card.question,
               answer: card.answer,
               flipped: false,
               reads: card.reads,
               difficulty: card.difficulty,
-            },
-            { remote: false }
-          )
+            }
         );
       }
-      await Promise.all(promDelete);
-      await Promise.all(promCreate);
+      await db.delete(null, { remote: true });
+      await db.create(cardsToCreate, { remote: false });
 
       // Reload the cards from the data store to update the view
       this.cards = await this.loadCards();
     },
     createRemoteCards: async function(cards) {
-      // We will be deleting many local cards at once and then recreating them
-      // remotely. For this we will need to create an array of promises and wait for
-      // them allto resolve
-      let promDelete = [];
-      let promCreate = [];
+      // We will be deleting all local cards at once and then recreating them
+      // remotely. 
+      let cardsToCreate = [];
       for (let card of cards) {
-        promDelete.push(db.delete(card.id, { remote: false }));
-        promCreate.push(
-          db.create(
+        cardsToCreate.push(
             {
               question: card.question,
               answer: card.answer,
               flipped: false,
               reads: card.reads,
               difficulty: card.difficulty,
-            },
-            { remote: true }
-          )
+            }
         );
       }
-      await Promise.all(promCreate);
-      await Promise.all(promDelete);
+
+      await db.delete(null, { remote: false })
+      await db.create(cardsToCreate, { remote: true });
+     
 
       // Reload the cards from the data store to update the view
       this.cards = await this.loadCards();

--- a/src/services/jsonbox.js
+++ b/src/services/jsonbox.js
@@ -171,8 +171,14 @@ const box = {
       //  the response echos back the data with _id, and _createdOn. We will rename
       // the _id for convenience in referencing in the app.
       let json = await response.json();
-      json.id = json["_id"];
-      delete json["_id"];
+
+      json.forEach((el, idx) => {
+        el.id = el["_id"];
+        delete el["_id"];
+        json[idx] = el;
+      });
+      
+
       return json;
     } else {
       return false;

--- a/src/services/jsonbox.js
+++ b/src/services/jsonbox.js
@@ -249,7 +249,9 @@ const box = {
     }
     let response;
 
-    response = await fetch(API_URL + "/" + id, options).catch(err => {
+    // can delete a single record or all of the records
+    const URL = id ? API_URL + "/" + id : API_URL;
+    response = await fetch(URL, options).catch(err => {
       console.log(err);
     });
 

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -148,23 +148,42 @@ const db = {
     localStorage.setItem(key, JSON.stringify(allCards));
   },
   delete: async function(id, options = {}) {
-    // Get all the cards
-    let allCards = JSON.parse(localStorage.getItem(key)) || {};
+    if(id){ 
+      // deleting a specific card
 
-    // delete the card from the cards collection
-    delete allCards[id];
+      // Get all the cards
+      let allCards = JSON.parse(localStorage.getItem(key)) || {};
 
-    // Save the updated cards collection
-    localStorage.setItem(key, JSON.stringify(allCards));
+      // delete the card from the cards collection
+      delete allCards[id];
 
-    // Only delete data on the remote database if remote flag is true
-    if (options.remote === true) {
-      await remote.delete(id).then(success => {
-        // If the remote database fails, we need to log the failure
-        if (!success) {
-          recordRemoteFail(id, "delete");
-        }
-      });
+      // Save the updated cards collection
+      localStorage.setItem(key, JSON.stringify(allCards));
+
+      // Only delete data on the remote database if remote flag is true
+      if (options.remote === true) {
+        await remote.delete(id).then(success => {
+          // If the remote database fails, we need to log the failure
+          if (!success) {
+            recordRemoteFail(id, "delete");
+          }
+        });
+      }
+    }
+    else{
+      // deleting all cards
+
+      localStorage.setItem(key, JSON.stringify({}));
+
+      if (options.remote === true) {
+        await remote.delete().then(success => {
+          // If the remote database fails, we need to log the failure
+          if (!success) {
+            recordRemoteFail("all", "delete");
+          }
+        });
+      }
+
     }
   }
 };

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -37,40 +37,51 @@ const db = {
   keepAlive: async function() {
     return await remote.read();
   },
-  create: async function(newCard, options = {}) {
+  create: async function(newCards, options = {}) {
     // Only create data on the remote database if remote flag is true
     if (options.remote === true) {
-      let result = await remote.create(newCard);
+      let result = await remote.create(newCards);
 
       // The call to the remote is successful
       if (result) {
         // The output from remote.create() should be to echo back the card data
         // with an extra key "id" which is provided by the remote database
-        newCard = result;
+        newCards = result;
         // Store last update time in local storage so we can check when local storage
         // is out of sync with server
-        localStorage.setItem("remoteUpdatedOn", result["_createdOn"]);
+        localStorage.setItem("remoteUpdatedOn", result[0]["_createdOn"]);
       }
       // The call to the remote is unsuccessful
       if (!result) {
         // If the remote database fails, we need to log the failure and provide
         // an id for the card so we can save it in the localStorage
-        let i = id();
-        newCard.id = i;
-        recordRemoteFail(i, "create");
+
+        newCards.forEach((el, idx) => {
+          let i = id();
+          newCards[idx].id = i;
+          recordRemoteFail(i, "create");
+        });
+
       }
-    } else {
+    } else { 
       // If only using local storage we need to provide an
-      //  id for the card so we can save it in the localStorage
-      let i = id();
-      newCard.id = i;
+      // id for the card so we can save it in the localStorage
+      newCards.forEach((el, idx) => {
+        let i = id();
+        newCards[idx].id = i;
+      });
+
     }
 
     // Get all the cards
     let allCards = JSON.parse(localStorage.getItem(key)) || {};
 
-    // Add the new card to cards collection
-    allCards[newCard.id] = newCard;
+    newCards.forEach((el) => {
+      // Add the new cards to cards collection
+      allCards[el.id] = el;
+    });
+
+
 
     // Save the updated cards collection
     localStorage.setItem(key, JSON.stringify(allCards));


### PR DESCRIPTION
If you import data from file or delete all your data then you may run into a problem. Currently importing data and delete all cards will fire off individual http requests to the jsonbox server, one request for each card. This can cause rate limiting issues. This PR uses bulk create and delete functionality of jsonbox to make these operations in a single http request.